### PR TITLE
 Added IPriceFeed.sol, PriceFeed.sol, PriceFeedProxy.sol

### DIFF
--- a/contracts/IERC20.sol
+++ b/contracts/IERC20.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
+ * the optional functions; to access them see {ERC20Detailed}.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/contracts/IPriceFeed.sol
+++ b/contracts/IPriceFeed.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./Ownable.sol";
+
+interface IPriceFeed {
+    function name() external view returns(string memory);
+    function getPriceInfo(string calldata symbol) external view returns(uint256, uint256, uint256);
+}

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        address msgSender = msg.sender;
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import './IERC20.sol';
+import './IPriceFeed.sol';
+
+contract PriceFeed is IPriceFeed, Ownable {
+	struct Price {
+		uint256 price;
+		uint256 priceLastUpdate;
+		uint256 priceTimesUpdate;
+		bool _exists;
+	}
+
+    mapping(string => Price) public prices;
+    string public priceFeedName;
+
+    constructor(string memory _name) public {
+    	priceFeedName = _name;
+    }
+
+    function getPriceInfo(string calldata symbol) external view returns(uint256, uint256, uint256) {
+    	return (prices[symbol].price, prices[symbol].priceLastUpdate, prices[symbol].priceTimesUpdate);
+    }
+    
+    function updatePrices(string[] calldata symbols, uint256[] calldata price) external onlyOwner {
+    	require(symbols.length == price.length, 'Symbols are less than Prices or viceversa');      
+        for(uint256 i = 0; i < symbols.length; i++) {
+            prices[symbols[i]] = Price({price: price[i], priceLastUpdate: now, priceTimesUpdate: 1, _exists: true});
+        }
+    }
+    
+    function name() external view returns(string memory) {
+    	return priceFeedName;
+    }
+
+    function withdraw(address _tokenAddress) public onlyOwner {
+        msg.sender.transfer(address(this).balance);
+        IERC20 token = IERC20(_tokenAddress);
+        uint256 balance = token.balanceOf(address(this));
+        token.transfer(msg.sender, balance);
+    }
+}

--- a/contracts/PriceFeedProxy.sol
+++ b/contracts/PriceFeedProxy.sol
@@ -1,0 +1,63 @@
+pragma solidity ^0.5.0;
+
+import "./Ownable.sol";
+import "./IPriceFeed.sol";
+
+contract PriceFeedProxy is Ownable {
+	struct PFStruct {
+		IPriceFeed _pf;
+		string _pfName;
+		address _pfOwner;
+		bool _exists;
+	}
+
+	modifier onlyPriceFeedOwner(string memory provider) { 
+		require (priceFeeds[provider]._pfOwner == msg.sender, 'Only PriceFeed owner can execute!'); 
+		_; 
+	}
+	
+	modifier existProvider(string memory provider) {
+		require(priceFeeds[provider]._exists, 'Provider not found!');
+		_;
+	}
+
+	modifier notExistProvider(string memory provider) {
+		require(!priceFeeds[provider]._exists, 'Provider found!');
+		_;
+	}
+
+	mapping(string => PFStruct) public priceFeeds;
+
+	function getPriceInfo(string calldata provider, string calldata symbol) external view 
+	existProvider(provider) returns(uint256, uint256, uint256) 
+	{
+		return priceFeeds[provider]._pf.getPriceInfo(symbol);
+	}
+
+	function addPriceFeed(string calldata provider, address addr) external 
+	notExistProvider(provider) 
+	{
+		IPriceFeed priceFeed = IPriceFeed(addr);
+		priceFeeds[provider] = PFStruct({_pf: priceFeed, _pfName: priceFeed.name(), _pfOwner: msg.sender, _exists: true});
+	}
+
+	function deletePriceFeed(string calldata provider) external 
+	onlyPriceFeedOwner(provider) 
+	{
+		priceFeeds[provider]._exists = false;
+	}
+
+	function updatePriceFeedAddress(string calldata provider, address addr) external
+	onlyPriceFeedOwner(provider) 
+	{
+		PFStruct storage priceFeed = priceFeeds[provider];
+		priceFeed._pf = IPriceFeed(addr);
+		priceFeed._pfName = priceFeed._pf.name();
+	}
+
+	function updatePriceFeedOwner(string calldata provider, address newOwner) external
+	onlyPriceFeedOwner(provider)
+	{
+		priceFeeds[provider]._pfOwner = newOwner;
+	}
+}


### PR DESCRIPTION
`IPriceFeed.sol` represents the standard inteface to implement for data providers to add their smart contracts to `PriceFeedProxy` contract.
`PriceFeedProxy` is a proxy for calling data providers contracts and a registry for them.
In `PriceFeed.sol` the `IPriceFeed` interface is implemented and can be an example of how data providers can implement their contract.